### PR TITLE
fix: remove payment_intent_data from subscription checkout sessions

### DIFF
--- a/src/app/actions/subscriptionActions.ts
+++ b/src/app/actions/subscriptionActions.ts
@@ -123,10 +123,6 @@ async function createCheckoutSession(
     billing_address_collection: isNewCustomer ? 'required' : 'auto',
   };
 
-  if (isNewCustomer) {
-    sessionParams.payment_intent_data = { setup_future_usage: 'off_session' };
-  }
-
   const session = await stripe().checkout.sessions.create(sessionParams);
 
   return {


### PR DESCRIPTION
Stripe doesn't allow `payment_intent_data` in subscription mode.