### PR TITLE
feat: add ParkFerndale service

### DIFF
--- a/src/app/[locale]/(auth)/parking/sessions/[sessionId]/page.tsx
+++ b/src/app/[locale]/(auth)/parking/sessions/[sessionId]/page.tsx
@@ -112,6 +112,8 @@ export default async function ParkingSessionPage(props: {
     duration_label: t('duration_label'),
     duration_range_parkdetroit: t('duration_range_parkdetroit'),
     duration_range_parkmobile: t('duration_range_parkmobile'),
+    duration_range_parkferndale: t('duration_range_parkferndale'),
+    parkferndale_do_not_back_disclaimer: t('parkferndale_do_not_back_disclaimer'),
     durationLabels: Object.fromEntries(
       PARKING_DURATION_I18N_KEYS.map(minutes => [
         parkingDurationTranslationKey(minutes),

--- a/src/components/parking/ParkingSessionClient.tsx
+++ b/src/components/parking/ParkingSessionClient.tsx
@@ -56,6 +56,8 @@ type ParkingSessionClientProps = {
     duration_label: string;
     duration_range_parkdetroit: string;
     duration_range_parkmobile: string;
+    duration_range_parkferndale: string;
+    parkferndale_do_not_back_disclaimer: string;
     durationLabels: Record<string, string>;
     note_label: string;
     duration_missing_hint: string;
@@ -148,13 +150,19 @@ function initialZoneCodeInput(detail: ParkingAssistSessionDetail): string {
 
 function durationRangeHintForService(
   serviceId: ParkingService | '',
-  translations: Pick<ParkingSessionClientProps['translations'], 'duration_range_parkdetroit' | 'duration_range_parkmobile'>,
+  translations: Pick<
+    ParkingSessionClientProps['translations'],
+    'duration_range_parkdetroit' | 'duration_range_parkmobile' | 'duration_range_parkferndale'
+  >,
 ): string | null {
   if (serviceId === 'parkdetroit') {
     return translations.duration_range_parkdetroit;
   }
   if (serviceId === 'parkmobile') {
     return translations.duration_range_parkmobile;
+  }
+  if (serviceId === 'parkferndale') {
+    return translations.duration_range_parkferndale;
   }
   return null;
 }
@@ -346,6 +354,7 @@ export function ParkingSessionClient({
   );
 
   const durationRangeHint = durationRangeHintForService(parkingServiceId, t);
+  const showParkFerndaleDisclaimer = parkingServiceId === 'parkferndale';
 
   const checkout = detail.latestCheckout;
   const showPaidCheckoutSummary = checkoutStatus === 'paid';
@@ -586,6 +595,9 @@ export function ParkingSessionClient({
                     onChangeAction={handleParkingServiceChange}
                     showSearch={false}
                   />
+                  {showParkFerndaleDisclaimer && (
+                    <p className={`${SECONDARY_VALUE_STYLE} mt-2`}>{t.parkferndale_do_not_back_disclaimer}</p>
+                  )}
                 </div>
               </div>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -95,6 +95,8 @@
     "duration_label": "Duration",
     "duration_range_parkdetroit": "Minimum parking duration is 1 hour. Maximum is 2 hours.",
     "duration_range_parkmobile": "Minimum parking duration is 30 minutes. Maximum is 3 hours.",
+    "duration_range_parkferndale": "Minimum parking duration is 30 minutes. Maximum is 2 hours.",
+    "parkferndale_do_not_back_disclaimer": "Do not back into spaces when parking with ParkFerndale.",
     "duration_option_30": "30 minutes",
     "duration_option_40": "40 minutes",
     "duration_option_50": "50 minutes",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -86,6 +86,8 @@
     "duration_label": "Durée",
     "duration_range_parkdetroit": "Durée minimale : 1 heure. Durée maximale : 2 heures.",
     "duration_range_parkmobile": "Durée minimale : 30 minutes. Durée maximale : 3 heures.",
+    "duration_range_parkferndale": "Durée minimale : 30 minutes. Durée maximale : 2 heures.",
+    "parkferndale_do_not_back_disclaimer": "Ne reculez pas dans les places lorsque vous stationnez avec ParkFerndale.",
     "duration_option_30": "30 minutes",
     "duration_option_40": "40 minutes",
     "duration_option_50": "50 minutes",

--- a/src/types/parking-assist.ts
+++ b/src/types/parking-assist.ts
@@ -5,7 +5,7 @@ export type ParkingCorporateCheckoutStatus
     | 'failed'
     | 'cancelled';
 
-export type ParkingService = 'parkdetroit' | 'parkmobile';
+export type ParkingService = 'parkdetroit' | 'parkmobile' | 'parkferndale';
 
 export type ParkingCorporateCheckout = {
   id: string;

--- a/src/utils/parking-services.test.ts
+++ b/src/utils/parking-services.test.ts
@@ -31,6 +31,18 @@ const catalog: ParkingServicesCatalog = {
         { minutes: 100, label: '1 hour 40 min' },
       ],
     },
+    {
+      id: 'parkferndale',
+      label: 'ParkFerndale',
+      zoneCodeHint: 'Zone code',
+      defaultDurationMinutes: 60,
+      durationOptions: [
+        { minutes: 30, label: '30 min' },
+        { minutes: 60, label: '1 hour' },
+        { minutes: 90, label: '1 hour 30 min' },
+        { minutes: 120, label: '2 hours' },
+      ],
+    },
   ],
 };
 
@@ -210,5 +222,19 @@ describe('parking-services', () => {
       parkingServiceId: 'parkmobile',
       durationMinutes: 30,
     });
+  });
+
+  it('uses suggested ParkFerndale service and minimum duration', () => {
+    expect(initialParkingCheckoutSelections(catalog, null, 'parkferndale')).toEqual({
+      parkingServiceId: 'parkferndale',
+      durationMinutes: 30,
+    });
+  });
+
+  it('validates ParkFerndale duration options', () => {
+    const entry = findCatalogService(catalog, 'parkferndale');
+
+    expect(isDurationAllowedForCatalogService(entry, 120)).toBe(true);
+    expect(isDurationAllowedForCatalogService(entry, 45)).toBe(false);
   });
 });

--- a/src/utils/parking-services.ts
+++ b/src/utils/parking-services.ts
@@ -26,11 +26,14 @@ export const PARKMOBILE_DURATION_MINUTES_OPTIONS = [
   180,
 ] as const;
 
+export const PARKFERNDALE_DURATION_MINUTES_OPTIONS = [30, 60, 90, 120] as const;
+
 /** All duration minutes that have locale keys under Parking.duration_option_ */
 export const PARKING_DURATION_I18N_KEYS = [
   ...new Set([
     ...PARKDETROIT_DURATION_MINUTES_OPTIONS,
     ...PARKMOBILE_DURATION_MINUTES_OPTIONS,
+    ...PARKFERNDALE_DURATION_MINUTES_OPTIONS,
   ]),
 ].sort((a, b) => a - b) as readonly number[];
 


### PR DESCRIPTION
PR includes:
- Updates the parking assist UI to recognize ParkFerndale as a parking service from the backend catalog
- Duration pickers and validation use ParkFerndale's 30 - 120 minute options (in 30-minute steps)
- Ferndale-specific copy includes duration range text and a “do not back into spaces” disclaimer on the session screen