### PR TITLE
feat: add delegate page for DIMO voting power

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/layout.tsx
+++ b/src/app/[locale]/(auth)/dashboard/layout.tsx
@@ -22,6 +22,7 @@ export default async function DashboardLayout(props: {
         parking_link: t('parking_link'),
         transactions_link: t('transactions_link'),
         recovery_link: t('recovery_link'),
+        delegate_link: t('delegate_link'),
         user_profile_link: t('user_profile_link'),
         sign_out: t('sign_out'),
       }}

--- a/src/app/[locale]/(auth)/delegate/DelegateClient.tsx
+++ b/src/app/[locale]/(auth)/delegate/DelegateClient.tsx
@@ -1,0 +1,373 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { DelegateIcon } from '@/components/Icons';
+import { Loading } from '@/components/Loading';
+import { PageHeader } from '@/components/ui';
+import { useDelegation } from '@/hooks/useDelegation';
+import { useStripeCustomer } from '@/hooks/useStripeCustomer';
+import { getDelegationContracts, isTestnetFlow } from '@/services/delegation/constants';
+import {
+  formatDimoAmount,
+  isSameAddress,
+  isValidDelegateeAddress,
+  shortenAddress,
+} from '@/services/delegation/delegation-service';
+import { getExplorerUrl } from '@/services/transaction-builder';
+import { BORDER_RADIUS, COLORS } from '@/utils/designSystem';
+
+type DelegateClientProps = {
+  translations: {
+    title: string;
+    description: string;
+  };
+};
+
+const { chainId, tokenSymbol } = getDelegationContracts();
+
+export function DelegateClient({ translations }: DelegateClientProps) {
+  const router = useRouter();
+  const { customerId, loading: customerLoading, error: customerError } = useStripeCustomer();
+  const {
+    walletAddress,
+    state,
+    loading,
+    error,
+    submit,
+    delegateTo,
+    resetSubmit,
+  } = useDelegation();
+
+  const [addressInput, setAddressInput] = useState('');
+  const [touched, setTouched] = useState(false);
+
+  useEffect(() => {
+    if (customerLoading) {
+      return;
+    }
+
+    if (customerError || !customerId) {
+      router.push('/');
+    }
+  }, [customerId, customerLoading, customerError, router]);
+
+  const trimmedInput = addressInput.trim();
+  const inputValid = isValidDelegateeAddress(trimmedInput);
+  const sameAsCurrent = Boolean(
+    inputValid && state?.isDelegated && isSameAddress(trimmedInput, state.delegatee),
+  );
+  const busy = submit.phase === 'authorizing' || submit.phase === 'submitting' || submit.phase === 'confirming';
+  const isSelfDelegated = Boolean(
+    state?.isDelegated && walletAddress && isSameAddress(state.delegatee, walletAddress),
+  );
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setAddressInput(event.target.value);
+    if (submit.phase === 'success' || submit.phase === 'error') {
+      resetSubmit();
+    }
+  };
+
+  const handleSelfDelegate = () => {
+    if (walletAddress) {
+      setAddressInput(walletAddress);
+      setTouched(true);
+      if (submit.phase === 'success' || submit.phase === 'error') {
+        resetSubmit();
+      }
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!inputValid || sameAsCurrent || busy) {
+      return;
+    }
+
+    await delegateTo(trimmedInput as `0x${string}`);
+  };
+
+  const buttonLabel = () => {
+    switch (submit.phase) {
+      case 'authorizing':
+        return 'Waiting for passkey…';
+      case 'submitting':
+        return 'Submitting…';
+      case 'confirming':
+        return 'Confirming on-chain…';
+      default:
+        return state?.isDelegated ? 'Update Delegation' : 'Delegate';
+    }
+  };
+
+  const renderAddress = (address: string) => (
+    <>
+      <span className="font-mono md:hidden">{shortenAddress(address)}</span>
+      <span className="hidden font-mono md:inline">{address}</span>
+    </>
+  );
+
+  const renderStatusCard = () => {
+    if (loading || customerLoading) {
+      return (
+        <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
+          <div className="flex items-center justify-center py-8">
+            <Loading className="mx-auto" />
+          </div>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p className="text-red-800 text-sm">{error}</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (!state || !walletAddress) {
+      return null;
+    }
+
+    return (
+      <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
+        <h3 className={`text-lg font-semibold ${COLORS.text.primary} mb-4`}>Your Voting Power</h3>
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className={`${BORDER_RADIUS.lg} bg-surface-sunken p-4`}>
+              <p className="text-xs text-gray-500 mb-1">
+                {tokenSymbol}
+                {' '}
+                Balance
+              </p>
+              <p className={`text-xl font-semibold ${COLORS.text.primary}`}>
+                {formatDimoAmount(state.balance)}
+                <span className="ml-1.5 text-sm font-normal text-gray-500">{tokenSymbol}</span>
+              </p>
+            </div>
+            <div className={`${BORDER_RADIUS.lg} bg-surface-sunken p-4`}>
+              <p className="text-xs text-gray-500 mb-1">Voting Power</p>
+              <p className={`text-xl font-semibold ${COLORS.text.primary}`}>
+                {formatDimoAmount(state.votes)}
+                <span className="ml-1.5 text-sm font-normal text-gray-500">votes</span>
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-sm text-gray-500 mb-1">Your Wallet</p>
+            <div className="flex flex-row rounded-md bg-surface-sunken px-4 py-2 w-full text-gray-400 text-sm items-center">
+              {renderAddress(walletAddress)}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-sm text-gray-500 mb-1">Currently Delegated To</p>
+            <div className="flex flex-row rounded-md bg-surface-sunken px-4 py-2 w-full text-sm items-center justify-between gap-2">
+              {state.isDelegated
+                ? (
+                    <span className={`${COLORS.text.primary} min-w-0 truncate`}>
+                      {renderAddress(state.delegatee)}
+                    </span>
+                  )
+                : (
+                    <span className="text-gray-400">No delegate set</span>
+                  )}
+              {isSelfDelegated && (
+                <span className="shrink-0 rounded-full bg-dimo-blue/10 px-2.5 py-0.5 text-xs font-medium text-dimo-blue">
+                  Self
+                </span>
+              )}
+              {!state.isDelegated && (
+                <span className="shrink-0 rounded-full bg-gray-700 px-2.5 py-0.5 text-xs font-medium text-gray-300">
+                  Not delegated
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  const renderFormCard = () => {
+    if (loading || customerLoading || error || !state || !walletAddress) {
+      return null;
+    }
+
+    return (
+      <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
+        <h3 className={`text-lg font-semibold ${COLORS.text.primary} mb-4`}>
+          {state.isDelegated ? 'Change Your Delegate' : 'Choose a Delegate'}
+        </h3>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="delegatee-address" className="block text-sm font-medium mb-1">
+              Delegate Address
+            </label>
+            <input
+              id="delegatee-address"
+              name="delegatee-address"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="0x…"
+              value={addressInput}
+              onChange={handleInputChange}
+              onBlur={() => setTouched(true)}
+              disabled={busy}
+              className="rounded-md bg-surface-sunken px-4 py-2 w-full font-mono text-sm placeholder:text-gray-600 disabled:opacity-60"
+            />
+            <div className="mt-1.5 flex items-center justify-between gap-2">
+              <p className="text-xs text-gray-500">
+                The address that will vote with your
+                {' '}
+                {tokenSymbol}
+                . You keep full control of your tokens.
+              </p>
+              <button
+                type="button"
+                onClick={handleSelfDelegate}
+                disabled={busy}
+                className="shrink-0 text-xs text-dimo-blue hover:underline cursor-pointer disabled:opacity-60"
+              >
+                Delegate to myself
+              </button>
+            </div>
+          </div>
+
+          {touched && trimmedInput.length > 0 && !inputValid && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-800 text-sm">
+                Enter a valid Ethereum address (0x followed by 40 hex characters). The zero address is not allowed.
+              </p>
+            </div>
+          )}
+
+          {sameAsCurrent && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+              <p className="text-yellow-800 text-sm">
+                Your voting power is already delegated to this address.
+              </p>
+            </div>
+          )}
+
+          {submit.phase === 'error' && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-800 text-sm">{submit.message}</p>
+            </div>
+          )}
+
+          {submit.phase === 'success' && (
+            <div className="p-3 bg-green-50 border border-green-200 rounded-md">
+              <div className="flex items-start">
+                <div className="shrink-0">
+                  <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <div className="ml-3 min-w-0">
+                  <p className="text-sm font-medium text-green-800">
+                    {submit.confirmed
+                      ? 'Delegation updated — your voting power is now active.'
+                      : 'Delegation submitted — waiting for it to land on-chain. Check back in a moment.'}
+                  </p>
+                  <p className="text-xs text-green-600 mt-1 truncate font-mono">
+                    UserOp:
+                    {' '}
+                    {shortenAddress(submit.userOpHash)}
+                  </p>
+                  <p className="text-xs text-green-600 mt-1">
+                    <a
+                      href={getExplorerUrl(chainId, walletAddress, 'address')}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-green-800"
+                    >
+                      View account activity →
+                    </a>
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {submit.phase === 'confirming' && (
+            <p className="text-xs text-gray-500">
+              Transaction submitted — waiting for it to land on-chain…
+            </p>
+          )}
+
+          <div className="flex flex-col pt-2">
+            <button
+              type="submit"
+              disabled={!inputValid || sameAsCurrent || busy}
+              className={`${BORDER_RADIUS.full} font-medium w-full py-3 px-4 ${
+                !inputValid || sameAsCurrent || busy
+                  ? 'bg-gray-400 text-gray-200 cursor-not-allowed'
+                  : 'bg-blue-600 text-white hover:bg-blue-700 cursor-pointer'
+              }`}
+            >
+              {buttonLabel()}
+            </button>
+            {isTestnetFlow && (
+              <p className="text-xs text-gray-500 mt-2 text-center">
+                Currently testing on Polygon Amoy
+              </p>
+            )}
+          </div>
+        </form>
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex flex-1 flex-col gap-4">
+      {/* Header */}
+      <PageHeader icon={<DelegateIcon />} title={translations.title} className="mb-0" />
+
+      <div className="flex flex-col gap-4 mb-4">
+        <div className="flex flex-col">
+          <h3 className="text-base font-medium leading-6">How This Works</h3>
+          <p className="text-sm text-text-secondary font-light leading-4.5 mt-1">
+            DIMO uses on-chain governance. Holding
+            {' '}
+            {tokenSymbol}
+            {' '}
+            gives you zero voting power until you delegate it — even to yourself. Delegating never moves or locks your tokens, and you can change your delegate at any time.
+          </p>
+          <p className="text-sm text-text-secondary font-light leading-4.5 mt-1">
+            Staked
+            {' '}
+            {tokenSymbol}
+            {' '}
+            is delegated separately and is not covered by this page.
+          </p>
+        </div>
+      </div>
+
+      {/* Not delegated warning */}
+      {!loading && !error && state && !state.isDelegated && state.balance > BigInt(0) && (
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <p className="text-yellow-800 text-sm">
+            Your
+            {' '}
+            {tokenSymbol}
+            {' '}
+            currently has no voting power. Delegate to yourself or another address to activate it.
+          </p>
+        </div>
+      )}
+
+      {/* Status */}
+      {renderStatusCard()}
+
+      {/* Delegate form */}
+      {renderFormCard()}
+    </div>
+  );
+}

--- a/src/app/[locale]/(auth)/delegate/DelegateClient.tsx
+++ b/src/app/[locale]/(auth)/delegate/DelegateClient.tsx
@@ -57,6 +57,9 @@ export function DelegateClient({ translations }: DelegateClientProps) {
   const sameAsCurrent = Boolean(
     inputValid && state?.isDelegated && isSameAddress(trimmedInput, state.delegatee),
   );
+  const sameAsWallet = Boolean(
+    inputValid && walletAddress && isSameAddress(trimmedInput, walletAddress),
+  );
   const busy = submit.phase === 'authorizing' || submit.phase === 'submitting' || submit.phase === 'confirming';
   const isSelfDelegated = Boolean(
     state?.isDelegated && walletAddress && isSameAddress(state.delegatee, walletAddress),
@@ -69,19 +72,9 @@ export function DelegateClient({ translations }: DelegateClientProps) {
     }
   };
 
-  const handleSelfDelegate = () => {
-    if (walletAddress) {
-      setAddressInput(walletAddress);
-      setTouched(true);
-      if (submit.phase === 'success' || submit.phase === 'error') {
-        resetSubmit();
-      }
-    }
-  };
-
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!inputValid || sameAsCurrent || busy) {
+    if (!inputValid || sameAsCurrent || sameAsWallet || busy) {
       return;
     }
 
@@ -222,22 +215,12 @@ export function DelegateClient({ translations }: DelegateClientProps) {
               disabled={busy}
               className="rounded-md bg-surface-sunken px-4 py-2 w-full font-mono text-sm placeholder:text-gray-600 disabled:opacity-60"
             />
-            <div className="mt-1.5 flex items-center justify-between gap-2">
-              <p className="text-xs text-gray-500">
-                The address that will vote with your
-                {' '}
-                {tokenSymbol}
-                . You keep full control of your tokens.
-              </p>
-              <button
-                type="button"
-                onClick={handleSelfDelegate}
-                disabled={busy}
-                className="shrink-0 text-xs text-dimo-blue hover:underline cursor-pointer disabled:opacity-60"
-              >
-                Delegate to myself
-              </button>
-            </div>
+            <p className="mt-1.5 text-xs text-gray-500">
+              The address that will vote with your
+              {' '}
+              {tokenSymbol}
+              . You keep full control of your tokens.
+            </p>
           </div>
 
           {touched && trimmedInput.length > 0 && !inputValid && (
@@ -252,6 +235,14 @@ export function DelegateClient({ translations }: DelegateClientProps) {
             <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
               <p className="text-yellow-800 text-sm">
                 Your voting power is already delegated to this address.
+              </p>
+            </div>
+          )}
+
+          {sameAsWallet && !sameAsCurrent && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+              <p className="text-yellow-800 text-sm">
+                Self-delegation is not supported — DIMO governance votes run on Snapshot, which does not count power you delegate to yourself. Choose a different delegate address.
               </p>
             </div>
           )}
@@ -305,9 +296,9 @@ export function DelegateClient({ translations }: DelegateClientProps) {
           <div className="flex flex-col pt-2">
             <button
               type="submit"
-              disabled={!inputValid || sameAsCurrent || busy}
+              disabled={!inputValid || sameAsCurrent || sameAsWallet || busy}
               className={`${BORDER_RADIUS.full} font-medium w-full py-3 px-4 ${
-                !inputValid || sameAsCurrent || busy
+                !inputValid || sameAsCurrent || sameAsWallet || busy
                   ? 'bg-gray-400 text-gray-200 cursor-not-allowed'
                   : 'bg-blue-600 text-white hover:bg-blue-700 cursor-pointer'
               }`}
@@ -334,11 +325,11 @@ export function DelegateClient({ translations }: DelegateClientProps) {
         <div className="flex flex-col">
           <h3 className="text-base font-medium leading-6">How This Works</h3>
           <p className="text-sm text-text-secondary font-light leading-4.5 mt-1">
-            DIMO uses on-chain governance. Holding
+            DIMO governance votes run on Snapshot. Holding
             {' '}
             {tokenSymbol}
             {' '}
-            gives you zero voting power until you delegate it — even to yourself. Delegating never moves or locks your tokens, and you can change your delegate at any time.
+            gives you no voting power until you delegate it to a delegate address. Delegating never moves or locks your tokens, and you can change your delegate at any time.
           </p>
           <p className="text-sm text-text-secondary font-light leading-4.5 mt-1">
             Staked
@@ -350,15 +341,13 @@ export function DelegateClient({ translations }: DelegateClientProps) {
         </div>
       </div>
 
-      {/* Not delegated warning */}
-      {!loading && !error && state && !state.isDelegated && state.balance > BigInt(0) && (
+      {/* Not delegated / self-delegated warning */}
+      {!loading && !error && state && (!state.isDelegated || isSelfDelegated) && state.balance > BigInt(0) && (
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
           <p className="text-yellow-800 text-sm">
-            Your
-            {' '}
-            {tokenSymbol}
-            {' '}
-            currently has no voting power. Delegate to yourself or another address to activate it.
+            {isSelfDelegated
+              ? 'You are currently self-delegated, but Snapshot does not count self-delegated power in DIMO governance votes. Delegate to another address to activate your voting power.'
+              : `Your ${tokenSymbol} currently has no voting power. Delegate it to a delegate address to activate it.`}
           </p>
         </div>
       )}

--- a/src/app/[locale]/(auth)/delegate/DelegateLayoutClient.tsx
+++ b/src/app/[locale]/(auth)/delegate/DelegateLayoutClient.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import type { AuthNavigationTranslations } from '@/components/Layout';
+import { LayoutWrapper } from '@/components/Layout';
+
+type DelegateLayoutClientProps = {
+  children: React.ReactNode;
+  translations: AuthNavigationTranslations;
+};
+
+export function DelegateLayoutClient({ children, translations }: DelegateLayoutClientProps) {
+  return (
+    <LayoutWrapper layoutType="auth" translations={translations}>
+      {children}
+    </LayoutWrapper>
+  );
+}

--- a/src/app/[locale]/(auth)/delegate/layout.tsx
+++ b/src/app/[locale]/(auth)/delegate/layout.tsx
@@ -1,7 +1,7 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { LayoutWrapper } from '@/components/Layout';
+import { DelegateLayoutClient } from './DelegateLayoutClient';
 
-export default async function ParkingLayout(props: {
+export default async function DelegateLayout(props: {
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
@@ -13,8 +13,7 @@ export default async function ParkingLayout(props: {
   });
 
   return (
-    <LayoutWrapper
-      layoutType="auth"
+    <DelegateLayoutClient
       translations={{
         dashboard_link: t('dashboard_link'),
         subscriptions_link: t('subscriptions_link'),
@@ -28,6 +27,6 @@ export default async function ParkingLayout(props: {
       }}
     >
       {props.children}
-    </LayoutWrapper>
+    </DelegateLayoutClient>
   );
 }

--- a/src/app/[locale]/(auth)/delegate/loading.tsx
+++ b/src/app/[locale]/(auth)/delegate/loading.tsx
@@ -1,0 +1,53 @@
+import { BORDER_RADIUS, COLORS } from '@/utils/designSystem';
+
+function SkeletonBox({ className = '' }: { className?: string }) {
+  return (
+    <div className={`animate-pulse bg-gray-800 rounded ${className}`} />
+  );
+}
+
+export default function DelegateLoading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4">
+      {/* Page Header Skeleton */}
+      <div className="flex items-center gap-2">
+        <SkeletonBox className="w-6 h-6" />
+        <SkeletonBox className="w-48 h-6" />
+      </div>
+
+      {/* How This Works Section Skeleton */}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col">
+          <SkeletonBox className="w-32 h-6 mb-2" />
+          <SkeletonBox className="w-full h-4 mb-1" />
+          <SkeletonBox className="w-5/6 h-4 mb-1" />
+          <SkeletonBox className="w-3/4 h-4" />
+        </div>
+      </div>
+
+      {/* Status Card Skeleton */}
+      <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
+        <SkeletonBox className="w-48 h-7 mb-4" />
+        <div className="space-y-4">
+          <SkeletonBox className="w-full h-10 rounded-md" />
+          <SkeletonBox className="w-full h-10 rounded-md" />
+          <SkeletonBox className="w-2/3 h-10 rounded-md" />
+        </div>
+      </div>
+
+      {/* Delegate Form Card Skeleton */}
+      <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
+        <SkeletonBox className="w-56 h-7 mb-4" />
+        <div className="space-y-4">
+          <div>
+            <SkeletonBox className="w-40 h-4 mb-1" />
+            <SkeletonBox className="w-full h-10 rounded-md" />
+          </div>
+          <div className="pt-4">
+            <SkeletonBox className={`w-full h-12 ${BORDER_RADIUS.full}`} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(auth)/delegate/page.tsx
+++ b/src/app/[locale]/(auth)/delegate/page.tsx
@@ -1,0 +1,50 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { Suspense } from 'react';
+import { DimoAuthWrapper } from '@/components/auth/DimoAuthWrapper';
+import { DelegateClient } from './DelegateClient';
+
+export async function generateMetadata(props: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await props.params;
+  const t = await getTranslations({
+    locale,
+    namespace: 'Delegate',
+  });
+
+  return {
+    title: t('meta_title'),
+  };
+}
+
+async function DelegateContent(props: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await props.params;
+  setRequestLocale(locale);
+  const t = await getTranslations({
+    locale,
+    namespace: 'Delegate',
+  });
+
+  return (
+    <DelegateClient
+      translations={{
+        title: t('title'),
+        description: t('description'),
+      }}
+    />
+  );
+}
+
+export default async function DelegatePage(props: {
+  params: Promise<{ locale: string }>;
+}) {
+  return (
+    <DimoAuthWrapper>
+      <Suspense>
+        <DelegateContent params={props.params} />
+      </Suspense>
+    </DimoAuthWrapper>
+  );
+}

--- a/src/app/[locale]/(auth)/payment-methods/layout.tsx
+++ b/src/app/[locale]/(auth)/payment-methods/layout.tsx
@@ -21,6 +21,7 @@ export default async function PaymentMethodsLayout(props: {
         parking_link: t('parking_link'),
         transactions_link: t('transactions_link'),
         recovery_link: t('recovery_link'),
+        delegate_link: t('delegate_link'),
         user_profile_link: t('user_profile_link'),
         sign_out: t('sign_out'),
       }}

--- a/src/app/[locale]/(auth)/recovery/layout.tsx
+++ b/src/app/[locale]/(auth)/recovery/layout.tsx
@@ -21,6 +21,7 @@ export default async function RecoveryLayout(props: {
         parking_link: t('parking_link'),
         transactions_link: t('transactions_link'),
         recovery_link: t('recovery_link'),
+        delegate_link: t('delegate_link'),
         user_profile_link: t('user_profile_link'),
         sign_out: t('sign_out'),
       }}

--- a/src/app/[locale]/(auth)/subscriptions/layout.tsx
+++ b/src/app/[locale]/(auth)/subscriptions/layout.tsx
@@ -22,6 +22,7 @@ export default async function SubscriptionsLayout(props: {
         parking_link: t('parking_link'),
         transactions_link: t('transactions_link'),
         recovery_link: t('recovery_link'),
+        delegate_link: t('delegate_link'),
         user_profile_link: t('user_profile_link'),
         sign_out: t('sign_out'),
       }}

--- a/src/app/[locale]/(auth)/transactions/layout.tsx
+++ b/src/app/[locale]/(auth)/transactions/layout.tsx
@@ -21,6 +21,7 @@ export default async function TransactionsLayout(props: {
         parking_link: t('parking_link'),
         transactions_link: t('transactions_link'),
         recovery_link: t('recovery_link'),
+        delegate_link: t('delegate_link'),
         user_profile_link: t('user_profile_link'),
         sign_out: t('sign_out'),
       }}

--- a/src/components/Icons/DelegateIcon.tsx
+++ b/src/components/Icons/DelegateIcon.tsx
@@ -1,0 +1,19 @@
+import type { IconProps } from './index';
+
+export const DelegateIcon = ({ className, onClick }: IconProps) => (
+  <svg
+    className={className}
+    onClick={onClick}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
+    />
+  </svg>
+);

--- a/src/components/Icons/index.ts
+++ b/src/components/Icons/index.ts
@@ -8,6 +8,7 @@ export { ChevronIcon } from './ChevronIcon';
 export { CloseIcon } from './CloseIcon';
 export { ConnectionIcon } from './ConnectionIcon';
 export { CreditCardIcon } from './CreditCardIcon';
+export { DelegateIcon } from './DelegateIcon';
 export { DIMOLogo } from './DIMOLogo';
 export { EditIcon } from './EditIcon';
 export { HomeIcon } from './HomeIcon';

--- a/src/components/Layout/NavigationConfig.tsx
+++ b/src/components/Layout/NavigationConfig.tsx
@@ -1,12 +1,13 @@
 import type { MenuItemConfig } from '@/types/menu';
 import { SignOutButton } from '@/components/auth/SignOutButton';
-import { CarIcon, HomeIcon, LogoutIcon, RecoveryIcon, TransactionIcon, WalletIcon } from '@/components/Icons';
+import { CarIcon, DelegateIcon, HomeIcon, LogoutIcon, RecoveryIcon, TransactionIcon, WalletIcon } from '@/components/Icons';
 import { LocaleSwitcher } from '@/components/LocaleSwitcher';
 import { MenuActionButton } from '@/components/Menu/MenuActionButton';
 import { FEATURE_FLAGS } from '@/utils/FeatureFlags';
 
 export type AuthNavigationTranslations = {
   dashboard_link: string;
+  delegate_link: string;
   payment_methods_link: string;
   parking_link: string;
   recovery_link: string;
@@ -88,6 +89,15 @@ export const createAuthNavigation = (
     icon: RecoveryIcon,
     iconClassName: 'h-5 w-5 text-text-secondary',
     link: '/recovery/',
+    section: 'main',
+  });
+
+  // Add delegate link
+  menuItems.push({
+    label: translations.delegate_link,
+    icon: DelegateIcon,
+    iconClassName: 'h-5 w-5 text-text-secondary',
+    link: '/delegate/',
     section: 'main',
   });
 

--- a/src/hooks/useDelegation.ts
+++ b/src/hooks/useDelegation.ts
@@ -36,6 +36,7 @@ export const useDelegation = () => {
   const [error, setError] = useState<string | null>(null);
   const [submit, setSubmit] = useState<SubmitStatus>({ phase: 'idle' });
   const mountedRef = useRef(true);
+  const inFlightRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -110,12 +111,17 @@ export const useDelegation = () => {
   }, [session, readState]);
 
   const delegateTo = useCallback(async (delegatee: `0x${string}`) => {
+    if (inFlightRef.current) {
+      return;
+    }
+
     if (!session?.walletAddress || !session?.dimoToken || !session?.subOrganizationId) {
       setSubmit({ phase: 'error', message: 'Missing session data. Please sign out and sign in again.' });
       return;
     }
 
     const wallet = session.walletAddress as `0x${string}`;
+    inFlightRef.current = true;
 
     try {
       setSubmit({ phase: 'authorizing' });
@@ -162,6 +168,8 @@ export const useDelegation = () => {
         const message = err instanceof Error ? err.message : 'Delegation failed';
         setSubmit({ phase: 'error', message });
       }
+    } finally {
+      inFlightRef.current = false;
     }
   }, [session, readState]);
 

--- a/src/hooks/useDelegation.ts
+++ b/src/hooks/useDelegation.ts
@@ -1,0 +1,183 @@
+'use client';
+
+import type { DelegationState } from '@/services/delegation/delegation-service';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { buildDelegateCall, isSameAddress, readDelegationState } from '@/services/delegation/delegation-service';
+import { createRecoveryService } from '@/services/recovery/recovery-service';
+import { SupportedChains } from '@/services/recovery/turnkey-bridge';
+import { getPublicClient } from '@/services/recovery/zerodev-service';
+
+type SessionData = {
+  walletAddress?: string;
+  subOrganizationId?: string;
+  dimoToken?: string;
+};
+
+export type SubmitStatus
+  = | { phase: 'idle' }
+    | { phase: 'authorizing' }
+    | { phase: 'submitting' }
+    | { phase: 'confirming'; userOpHash: string }
+    | { phase: 'success'; userOpHash: string; confirmed: boolean }
+    | { phase: 'error'; message: string };
+
+const CONFIRM_POLL_INTERVAL_MS = 3000;
+const CONFIRM_POLL_ATTEMPTS = 10;
+
+const wait = (ms: number) => new Promise<void>((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+export const useDelegation = () => {
+  const [sessionLoading, setSessionLoading] = useState(true);
+  const [session, setSession] = useState<SessionData | null>(null);
+  const [state, setState] = useState<DelegationState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submit, setSubmit] = useState<SubmitStatus>({ phase: 'idle' });
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const readState = useCallback(async (wallet: `0x${string}`): Promise<DelegationState | null> => {
+    const publicClient = getPublicClient(SupportedChains.POLYGON);
+    try {
+      const next = await readDelegationState(publicClient, wallet);
+      if (mountedRef.current) {
+        setState(next);
+        setError(null);
+      }
+      return next;
+    } catch {
+      if (mountedRef.current) {
+        setError('Failed to load delegation state. Please try again.');
+      }
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const response = await fetch('/api/auth/me');
+        if (!response.ok) {
+          throw new Error('Failed to load session');
+        }
+
+        const data: SessionData = await response.json();
+        if (!mountedRef.current) {
+          return;
+        }
+
+        setSession(data);
+        setSessionLoading(false);
+
+        if (data.walletAddress) {
+          await readState(data.walletAddress as `0x${string}`);
+        } else {
+          setError('Wallet address not found in your session.');
+        }
+      } catch {
+        if (mountedRef.current) {
+          setSessionLoading(false);
+          setError('Failed to load your session. Please sign in again.');
+        }
+      } finally {
+        if (mountedRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+  }, [readState]);
+
+  const refetch = useCallback(async () => {
+    if (!session?.walletAddress) {
+      return;
+    }
+
+    setLoading(true);
+    await readState(session.walletAddress as `0x${string}`);
+    if (mountedRef.current) {
+      setLoading(false);
+    }
+  }, [session, readState]);
+
+  const delegateTo = useCallback(async (delegatee: `0x${string}`) => {
+    if (!session?.walletAddress || !session?.dimoToken || !session?.subOrganizationId) {
+      setSubmit({ phase: 'error', message: 'Missing session data. Please sign out and sign in again.' });
+      return;
+    }
+
+    const wallet = session.walletAddress as `0x${string}`;
+
+    try {
+      setSubmit({ phase: 'authorizing' });
+
+      const recoveryService = await createRecoveryService({
+        dimoToken: session.dimoToken,
+        subOrganizationId: session.subOrganizationId,
+        walletAddress: wallet,
+      });
+
+      setSubmit({ phase: 'submitting' });
+
+      const result = await recoveryService.executeTransaction({
+        targetChain: SupportedChains.POLYGON,
+        ...buildDelegateCall(delegatee),
+      });
+
+      if (!result.success || !result.transactionHash) {
+        throw new Error(result.error || 'Delegation transaction failed');
+      }
+
+      const userOpHash = result.transactionHash;
+      setSubmit({ phase: 'confirming', userOpHash });
+
+      for (let attempt = 0; attempt < CONFIRM_POLL_ATTEMPTS; attempt++) {
+        await wait(CONFIRM_POLL_INTERVAL_MS);
+
+        const next = await readState(wallet);
+        if (!mountedRef.current) {
+          return;
+        }
+
+        if (next && isSameAddress(next.delegatee, delegatee)) {
+          setSubmit({ phase: 'success', userOpHash, confirmed: true });
+          return;
+        }
+      }
+
+      if (mountedRef.current) {
+        setSubmit({ phase: 'success', userOpHash, confirmed: false });
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        const message = err instanceof Error ? err.message : 'Delegation failed';
+        setSubmit({ phase: 'error', message });
+      }
+    }
+  }, [session, readState]);
+
+  const resetSubmit = useCallback(() => {
+    setSubmit({ phase: 'idle' });
+  }, []);
+
+  return {
+    sessionLoading,
+    walletAddress: (session?.walletAddress as `0x${string}` | undefined) ?? null,
+    state,
+    loading,
+    error,
+    refetch,
+    submit,
+    delegateTo,
+    resetSubmit,
+  };
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,6 +30,7 @@
     "parking_link": "Parking",
     "transactions_link": "Transactions",
     "recovery_link": "Recovery",
+    "delegate_link": "Delegate",
     "user_profile_link": "Account",
     "sign_out": "Sign out"
   },
@@ -144,6 +145,11 @@
     "pending_queued_message": "Payment is still processing. Refresh this page to check the latest status.",
     "pay_submitted_message": "Your payment was submitted. You can close this page. We'll send a notification when checkout finishes, usually within a few minutes.",
     "suggested_service_hint": "Suggested service for this location: {service}"
+  },
+  "Delegate": {
+    "meta_title": "Delegate",
+    "title": "Delegate",
+    "description": "Delegate your DIMO voting power"
   },
   "monthly": "monthly",
   "annually": "annually"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -30,6 +30,7 @@
     "parking_link": "Parking",
     "transactions_link": "Transactions",
     "recovery_link": "Récupération",
+    "delegate_link": "Déléguer",
     "user_profile_link": "Gérer votre compte",
     "sign_out": "Se déconnecter"
   },
@@ -141,6 +142,11 @@
     "title": "Récupération",
     "description": "Récupération",
     "coming_soon": "Coming soon"
+  },
+  "Delegate": {
+    "meta_title": "Déléguer",
+    "title": "Déléguer",
+    "description": "Déléguez votre pouvoir de vote DIMO"
   },
   "monthly": "monthly",
   "annually": "annually"

--- a/src/services/delegation/abi.ts
+++ b/src/services/delegation/abi.ts
@@ -1,0 +1,32 @@
+// ERC20Votes surface of the DIMO token (OZ v4), verbatim from
+// dimo-token/abis/contracts/Polygon/Mainnet/ChildToken/DimoV3.sol/Dimo.json
+export const DIMO_VOTES_ABI = [
+  {
+    inputs: [{ internalType: 'address', name: 'delegatee', type: 'address' }],
+    name: 'delegate',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'delegates',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'getVotes',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;

--- a/src/services/delegation/constants.ts
+++ b/src/services/delegation/constants.ts
@@ -1,0 +1,23 @@
+export type DelegationContracts = {
+  chainId: number;
+  dimoToken: `0x${string}`;
+  tokenSymbol: string;
+};
+
+export const isTestnetFlow = process.env.NEXT_PUBLIC_RECOVERY_FLOW === 'testnet';
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+// DIMO governance lives on Polygon. Amoy uses the OMID test token.
+export const getDelegationContracts = (): DelegationContracts =>
+  isTestnetFlow
+    ? {
+        chainId: 80002,
+        dimoToken: '0x21cFE003997fB7c2B3cfe5cf71e7833B7B2eCe10',
+        tokenSymbol: 'OMID',
+      }
+    : {
+        chainId: 137,
+        dimoToken: '0xE261D618a959aFfFd53168Cd07D12E37B26761db',
+        tokenSymbol: 'DIMO',
+      };

--- a/src/services/delegation/delegation-service.test.ts
+++ b/src/services/delegation/delegation-service.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getDelegationContracts, ZERO_ADDRESS } from './constants';
+import {
+  buildDelegateCall,
+  encodeDelegateCallData,
+  formatDimoAmount,
+  isSameAddress,
+  isValidDelegateeAddress,
+  readDelegationState,
+  shortenAddress,
+} from './delegation-service';
+
+const WALLET = '0x1234567890AbcdEF1234567890aBcdef12345678' as const;
+const DELEGATEE = '0xE261D618a959aFfFd53168Cd07D12E37B26761db' as const;
+
+describe('isValidDelegateeAddress', () => {
+  it('accepts a lowercase address', () => {
+    expect(isValidDelegateeAddress('0xe261d618a959afffd53168cd07d12e37b26761db')).toBe(true);
+  });
+
+  it('accepts a checksummed address', () => {
+    expect(isValidDelegateeAddress(DELEGATEE)).toBe(true);
+  });
+
+  it('rejects a short address', () => {
+    expect(isValidDelegateeAddress('0xe261d618')).toBe(false);
+  });
+
+  it('rejects a missing 0x prefix', () => {
+    expect(isValidDelegateeAddress('e261d618a959afffd53168cd07d12e37b26761db00')).toBe(false);
+  });
+
+  it('rejects non-hex characters', () => {
+    expect(isValidDelegateeAddress('0xZ261d618a959afffd53168cd07d12e37b26761db')).toBe(false);
+  });
+
+  it('rejects whitespace-padded input', () => {
+    expect(isValidDelegateeAddress(` ${DELEGATEE} `)).toBe(false);
+  });
+
+  it('rejects the zero address', () => {
+    expect(isValidDelegateeAddress(ZERO_ADDRESS)).toBe(false);
+  });
+});
+
+describe('isSameAddress', () => {
+  it('compares case-insensitively', () => {
+    expect(isSameAddress(DELEGATEE, DELEGATEE.toLowerCase())).toBe(true);
+  });
+
+  it('detects different addresses', () => {
+    expect(isSameAddress(DELEGATEE, WALLET)).toBe(false);
+  });
+});
+
+describe('encodeDelegateCallData', () => {
+  it('encodes the delegate(address) selector with a padded address', () => {
+    expect(encodeDelegateCallData(DELEGATEE)).toBe(
+      '0x5c19a95c000000000000000000000000e261d618a959afffd53168cd07d12e37b26761db',
+    );
+  });
+});
+
+describe('buildDelegateCall', () => {
+  it('targets the delegate function with the delegatee parameter', () => {
+    const call = buildDelegateCall(DELEGATEE);
+
+    expect(call.functionName).toBe('delegate');
+    expect(call.parameters).toEqual([DELEGATEE]);
+    expect(call.contractAddress).toBe(getDelegationContracts().dimoToken);
+  });
+});
+
+describe('readDelegationState', () => {
+  type ReadArgs = { address: string; functionName: string; args: readonly string[] };
+
+  const stubClient = (delegatee: string, balance: bigint, votes: bigint) => ({
+    readContract: vi.fn(async ({ functionName }: ReadArgs) => {
+      if (functionName === 'delegates') {
+        return delegatee;
+      }
+
+      if (functionName === 'balanceOf') {
+        return balance;
+      }
+
+      return votes;
+    }),
+  });
+
+  it('maps chain reads into delegation state', async () => {
+    const client = stubClient(DELEGATEE, BigInt('1500000000000000000'), BigInt('1500000000000000000'));
+
+    const state = await readDelegationState(client, WALLET);
+
+    expect(state).toEqual({
+      delegatee: DELEGATEE,
+      isDelegated: true,
+      balance: BigInt('1500000000000000000'),
+      votes: BigInt('1500000000000000000'),
+    });
+  });
+
+  it('reports not delegated for the zero address', async () => {
+    const client = stubClient(ZERO_ADDRESS, BigInt(5), BigInt(0));
+
+    const state = await readDelegationState(client, WALLET);
+
+    expect(state.isDelegated).toBe(false);
+    expect(state.votes).toBe(BigInt(0));
+  });
+
+  it('queries the configured token contract for all three reads', async () => {
+    const client = stubClient(ZERO_ADDRESS, BigInt(0), BigInt(0));
+
+    await readDelegationState(client, WALLET);
+
+    expect(client.readContract).toHaveBeenCalledTimes(3);
+
+    for (const call of client.readContract.mock.calls) {
+      expect(call[0].address).toBe(getDelegationContracts().dimoToken);
+      expect(call[0].args).toEqual([WALLET]);
+    }
+  });
+});
+
+describe('formatDimoAmount', () => {
+  it('formats zero', () => {
+    expect(formatDimoAmount(BigInt(0))).toBe('0');
+  });
+
+  it('formats fractional amounts', () => {
+    expect(formatDimoAmount(BigInt('1500000000000000000'))).toBe('1.5');
+  });
+
+  it('truncates long fractions to four places', () => {
+    expect(formatDimoAmount(BigInt('1123456789000000000'))).toBe('1.1234');
+  });
+
+  it('adds thousands separators for large amounts', () => {
+    expect(formatDimoAmount(BigInt('25000000000000000000000'))).toBe('25,000');
+  });
+});
+
+describe('shortenAddress', () => {
+  it('shortens a full address', () => {
+    expect(shortenAddress(DELEGATEE)).toBe('0xE261...61db');
+  });
+
+  it('returns short inputs unchanged', () => {
+    expect(shortenAddress('0x1234')).toBe('0x1234');
+  });
+});

--- a/src/services/delegation/delegation-service.ts
+++ b/src/services/delegation/delegation-service.ts
@@ -1,0 +1,78 @@
+import { encodeFunctionData, formatUnits } from 'viem';
+import { DIMO_VOTES_ABI } from './abi';
+import { getDelegationContracts, ZERO_ADDRESS } from './constants';
+
+export type DelegationState = {
+  delegatee: `0x${string}`;
+  isDelegated: boolean;
+  balance: bigint;
+  votes: bigint;
+};
+
+export type DelegationReadClient = {
+  readContract: (args: {
+    address: `0x${string}`;
+    abi: typeof DIMO_VOTES_ABI;
+    functionName: 'delegates' | 'getVotes' | 'balanceOf';
+    args: readonly [`0x${string}`];
+  }) => Promise<unknown>;
+};
+
+const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+export const isValidDelegateeAddress = (input: string): boolean =>
+  ADDRESS_REGEX.test(input) && input.toLowerCase() !== ZERO_ADDRESS;
+
+export const isSameAddress = (a: string, b: string): boolean =>
+  a.toLowerCase() === b.toLowerCase();
+
+export const encodeDelegateCallData = (delegatee: `0x${string}`): `0x${string}` =>
+  encodeFunctionData({
+    abi: DIMO_VOTES_ABI,
+    functionName: 'delegate',
+    args: [delegatee],
+  });
+
+export const buildDelegateCall = (delegatee: `0x${string}`) => ({
+  contractAddress: getDelegationContracts().dimoToken,
+  abi: DIMO_VOTES_ABI as unknown as any[],
+  functionName: 'delegate',
+  parameters: [delegatee],
+});
+
+export const readDelegationState = async (
+  client: DelegationReadClient,
+  wallet: `0x${string}`,
+): Promise<DelegationState> => {
+  const { dimoToken } = getDelegationContracts();
+
+  const [delegatee, balance, votes] = await Promise.all([
+    client.readContract({ address: dimoToken, abi: DIMO_VOTES_ABI, functionName: 'delegates', args: [wallet] }),
+    client.readContract({ address: dimoToken, abi: DIMO_VOTES_ABI, functionName: 'balanceOf', args: [wallet] }),
+    client.readContract({ address: dimoToken, abi: DIMO_VOTES_ABI, functionName: 'getVotes', args: [wallet] }),
+  ]);
+
+  return {
+    delegatee: delegatee as `0x${string}`,
+    isDelegated: !isSameAddress(delegatee as string, ZERO_ADDRESS),
+    balance: balance as bigint,
+    votes: votes as bigint,
+  };
+};
+
+export const formatDimoAmount = (wei: bigint): string => {
+  const formatted = formatUnits(wei, 18);
+  const [whole = '0', fraction = ''] = formatted.split('.');
+  const trimmedFraction = fraction.replace(/0+$/, '').slice(0, 4);
+  const withSeparators = Number(whole) >= 1000
+    ? Number(whole).toLocaleString('en-US')
+    : whole;
+  return trimmedFraction ? `${withSeparators}.${trimmedFraction}` : withSeparators;
+};
+
+export const shortenAddress = (address: string): string => {
+  if (!address || address.length < 10) {
+    return address;
+  }
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+};


### PR DESCRIPTION
## Summary

- New **Delegate** menu item + `/delegate` page (en + fr) following the `/recovery` feature pattern
- Shows wallet DIMO balance, current delegatee (with Self / Not delegated pills), and live voting power read from the Polygon token (`0xE261…61db`; Amoy OMID under `NEXT_PUBLIC_RECOVERY_FLOW=testnet`)
- Delegate / re-delegate to any 0x address via the existing smart-account stack (Turnkey passkey -> ZeroDev kernel userOp, paymaster-sponsored)
- Post-submit confirmation polls `delegates()` until the on-chain value flips (userOp hash is not a tx hash, so no receipt polling)
- Self-delegation is blocked with an explainer: DIMO governance votes run on Snapshot, which does not count self-delegated power; users already self-delegated on-chain get a warning
- Double-submit guarded (in-flight ref) so rapid clicks cannot fire two passkey ceremonies
- New `src/services/delegation/` module: ERC20Votes ABI fragments (verbatim from dimo-token DimoV3), per-env contract addresses, pure helpers with 20 unit tests

## Test plan

- [x] `npm run check-types`, `npm run lint`, `npm run test` (24/24)
- [x] `npm run build` — `/en/delegate` + `/fr/delegate` prerender
- [x] `delegates()` read verified against live Polygon and Amoy RPCs
- [ ] Manual passkey flow: sign in, delegate to an address, confirm status card flips