### PR TITLE
fix: remove misleading voting power stat and correct staked DIMO copy

### DIFF
--- a/src/app/[locale]/(auth)/delegate/DelegateClient.tsx
+++ b/src/app/[locale]/(auth)/delegate/DelegateClient.tsx
@@ -128,27 +128,18 @@ export function DelegateClient({ translations }: DelegateClientProps) {
 
     return (
       <div className={`${BORDER_RADIUS.xl} ${COLORS.background.secondary} p-6`}>
-        <h3 className={`text-lg font-semibold ${COLORS.text.primary} mb-4`}>Your Voting Power</h3>
+        <h3 className={`text-lg font-semibold ${COLORS.text.primary} mb-4`}>Your Delegation</h3>
         <div className="space-y-4">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <div className={`${BORDER_RADIUS.lg} bg-surface-sunken p-4`}>
-              <p className="text-xs text-gray-500 mb-1">
-                {tokenSymbol}
-                {' '}
-                Balance
-              </p>
-              <p className={`text-xl font-semibold ${COLORS.text.primary}`}>
-                {formatDimoAmount(state.balance)}
-                <span className="ml-1.5 text-sm font-normal text-gray-500">{tokenSymbol}</span>
-              </p>
-            </div>
-            <div className={`${BORDER_RADIUS.lg} bg-surface-sunken p-4`}>
-              <p className="text-xs text-gray-500 mb-1">Voting Power</p>
-              <p className={`text-xl font-semibold ${COLORS.text.primary}`}>
-                {formatDimoAmount(state.votes)}
-                <span className="ml-1.5 text-sm font-normal text-gray-500">votes</span>
-              </p>
-            </div>
+          <div className={`${BORDER_RADIUS.lg} bg-surface-sunken p-4`}>
+            <p className="text-xs text-gray-500 mb-1">
+              {tokenSymbol}
+              {' '}
+              Balance
+            </p>
+            <p className={`text-xl font-semibold ${COLORS.text.primary}`}>
+              {formatDimoAmount(state.balance)}
+              <span className="ml-1.5 text-sm font-normal text-gray-500">{tokenSymbol}</span>
+            </p>
           </div>
 
           <div>
@@ -336,7 +327,7 @@ export function DelegateClient({ translations }: DelegateClientProps) {
             {' '}
             {tokenSymbol}
             {' '}
-            is delegated separately and is not covered by this page.
+            cannot be delegated.
           </p>
         </div>
       </div>

--- a/src/services/delegation/abi.ts
+++ b/src/services/delegation/abi.ts
@@ -17,13 +17,6 @@ export const DIMO_VOTES_ABI = [
   },
   {
     inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
-    name: 'getVotes',
-    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
-  {
-    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
     name: 'balanceOf',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',

--- a/src/services/delegation/delegation-service.test.ts
+++ b/src/services/delegation/delegation-service.test.ts
@@ -74,22 +74,18 @@ describe('buildDelegateCall', () => {
 describe('readDelegationState', () => {
   type ReadArgs = { address: string; functionName: string; args: readonly string[] };
 
-  const stubClient = (delegatee: string, balance: bigint, votes: bigint) => ({
+  const stubClient = (delegatee: string, balance: bigint) => ({
     readContract: vi.fn(async ({ functionName }: ReadArgs) => {
       if (functionName === 'delegates') {
         return delegatee;
       }
 
-      if (functionName === 'balanceOf') {
-        return balance;
-      }
-
-      return votes;
+      return balance;
     }),
   });
 
   it('maps chain reads into delegation state', async () => {
-    const client = stubClient(DELEGATEE, BigInt('1500000000000000000'), BigInt('1500000000000000000'));
+    const client = stubClient(DELEGATEE, BigInt('1500000000000000000'));
 
     const state = await readDelegationState(client, WALLET);
 
@@ -97,25 +93,23 @@ describe('readDelegationState', () => {
       delegatee: DELEGATEE,
       isDelegated: true,
       balance: BigInt('1500000000000000000'),
-      votes: BigInt('1500000000000000000'),
     });
   });
 
   it('reports not delegated for the zero address', async () => {
-    const client = stubClient(ZERO_ADDRESS, BigInt(5), BigInt(0));
+    const client = stubClient(ZERO_ADDRESS, BigInt(5));
 
     const state = await readDelegationState(client, WALLET);
 
     expect(state.isDelegated).toBe(false);
-    expect(state.votes).toBe(BigInt(0));
   });
 
-  it('queries the configured token contract for all three reads', async () => {
-    const client = stubClient(ZERO_ADDRESS, BigInt(0), BigInt(0));
+  it('queries the configured token contract for both reads', async () => {
+    const client = stubClient(ZERO_ADDRESS, BigInt(0));
 
     await readDelegationState(client, WALLET);
 
-    expect(client.readContract).toHaveBeenCalledTimes(3);
+    expect(client.readContract).toHaveBeenCalledTimes(2);
 
     for (const call of client.readContract.mock.calls) {
       expect(call[0].address).toBe(getDelegationContracts().dimoToken);

--- a/src/services/delegation/delegation-service.ts
+++ b/src/services/delegation/delegation-service.ts
@@ -6,14 +6,13 @@ export type DelegationState = {
   delegatee: `0x${string}`;
   isDelegated: boolean;
   balance: bigint;
-  votes: bigint;
 };
 
 export type DelegationReadClient = {
   readContract: (args: {
     address: `0x${string}`;
     abi: typeof DIMO_VOTES_ABI;
-    functionName: 'delegates' | 'getVotes' | 'balanceOf';
+    functionName: 'delegates' | 'balanceOf';
     args: readonly [`0x${string}`];
   }) => Promise<unknown>;
 };
@@ -46,17 +45,15 @@ export const readDelegationState = async (
 ): Promise<DelegationState> => {
   const { dimoToken } = getDelegationContracts();
 
-  const [delegatee, balance, votes] = await Promise.all([
+  const [delegatee, balance] = await Promise.all([
     client.readContract({ address: dimoToken, abi: DIMO_VOTES_ABI, functionName: 'delegates', args: [wallet] }),
     client.readContract({ address: dimoToken, abi: DIMO_VOTES_ABI, functionName: 'balanceOf', args: [wallet] }),
-    client.readContract({ address: dimoToken, abi: DIMO_VOTES_ABI, functionName: 'getVotes', args: [wallet] }),
   ]);
 
   return {
     delegatee: delegatee as `0x${string}`,
     isDelegated: !isSameAddress(delegatee as string, ZERO_ADDRESS),
     balance: balance as bigint,
-    votes: votes as bigint,
   };
 };
 


### PR DESCRIPTION
## Summary

- Removes the Voting Power stat tile: `getVotes(wallet)` counts votes held *as a delegatee*, so it always reads 0 for anyone who delegates to another address — misleading next to a real balance. The `getVotes` read and ABI fragment are dropped entirely.
- Status card heading renamed to **Your Delegation** (it no longer shows a voting-power number).
- Staked DIMO callout now reads **"Staked DIMO cannot be delegated."**

## Test plan

- [x] `check-types`, `lint`, `test` (52/52)